### PR TITLE
[SFlow] Added an Option to have a traffic run before running the actual test

### DIFF
--- a/ansible/roles/test/files/ptftests/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/sflow_test.py
@@ -41,7 +41,7 @@ class SflowTest(BaseTest):
                 self.sflow_interfaces.append(index["ptf_indices"])
         logging.info("Sflow interfaces under Test : %s" %self.interfaces)
         self.src_ip_list = ['192.158.8.1','192.168.16.1', '192.168.24.1','192.168.32.1']
-        self.no_sflow = False
+        self.pre_learn_dst_mac = False
         if 'pre_learn_dst_mac' in self.test_params and self.test_params['pre_learn_dst_mac'] == 'yes':
             self.pre_learn_dst_mac = True
             return
@@ -59,8 +59,6 @@ class SflowTest(BaseTest):
             self.poll_tests = False
 
         self.collectors=['collector0','collector1']
-        self.collector0_samples = {}
-        self.collector1_samples = {}
 
     def tearDown(self):
         self.cmd(["supervisorctl", "stop", "arp_responder"])

--- a/ansible/roles/test/files/ptftests/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/sflow_test.py
@@ -33,17 +33,18 @@ class SflowTest(BaseTest):
             logging.info("%s : %s" %(param,value))
         self.router_mac = self.test_params['router_mac']
         self.dst_port = self.test_params['dst_port']
+        self.sflow_ports_file = self.test_params['sflow_ports_file']
+        self.sflow_interfaces = []
         with open(self.sflow_ports_file) as fp:
             self.interfaces = json.load(fp)
             for port,index in self.interfaces.items():
                 self.sflow_interfaces.append(index["ptf_indices"])
         logging.info("Sflow interfaces under Test : %s" %self.interfaces)
+        self.src_ip_list = ['192.158.8.1','192.168.16.1', '192.168.24.1','192.168.32.1']
         self.no_sflow = False
         if 'sflow_not_enabled' in self.test_params and self.test_params['sflow_not_enabled'] == 'yes':
             self.no_sflow = True
             return
-            
-        self.src_ip_list = ['192.158.8.1','192.168.16.1', '192.168.24.1','192.168.32.1']
 
         # Config required for running the test when the sflow is enabled
         if 'enabled_sflow_interfaces' in self.test_params:
@@ -51,8 +52,6 @@ class SflowTest(BaseTest):
 
         self.agent_id = self.test_params['agent_id']
         self.active_col = self.test_params['active_collectors']
-        self.sflow_interfaces = []
-        self.sflow_ports_file = self.test_params['sflow_ports_file']
         if 'polling_int' in self.test_params:
             self.poll_tests = True
             self.polling_int =  self.test_params['polling_int']
@@ -262,16 +261,17 @@ class SflowTest(BaseTest):
                         ip_ttl=64)
             send(self,src_port,tcp_pkt,count=1)
             index+=1
+        time.sleep(10)
 
     #--------------------------------------------------------------------------
 
     def runTest(self):
+        self.generate_ArpResponderConfig()
+        time.sleep(1)
         if self.no_sflow:
             self.sendTrafficNoSflow()
             return
 
-        self.generate_ArpResponderConfig()
-        time.sleep(1)
         self.stop_collector=False
         thr1 = threading.Thread(target=self.collector_0)
         thr2 = threading.Thread(target=self.collector_1)

--- a/tests/sflow/conftest.py
+++ b/tests/sflow/conftest.py
@@ -11,4 +11,10 @@ def pytest_addoption(parser):
         default=False,
         help="Enable sFlow feature on DUT",
     )
-    
+
+    parser.addoption(
+        "--enable_trail_run",
+        action="store_true",
+        default=False,
+        help="Have a Trail Traffic run before running the actual sFlow tests.",
+    )

--- a/tests/sflow/conftest.py
+++ b/tests/sflow/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--enable_trail_run",
+        "--pre_learn_dst_mac",
         action="store_true",
         default=False,
         help="Have a Trail Traffic run before running the actual sFlow tests.",

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -97,7 +97,7 @@ def setup_ptf(ptfhost, collector_ports, var, tbinfo, request):
         params = {'testbed_type': tbinfo['topo']['name'],
                   'router_mac': var['router_mac'],
                   'dst_port' : var['ptf_test_indices'][2],
-                  'sflow_not_enabled' : 'yes',
+                  'pre_learn_dst_mac' : 'yes',
                   'sflow_ports_file' : "/tmp/sflow_ports.json"}
 
         ptf_runner(host=ptfhost,

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -3,6 +3,8 @@
 
     Parameters:
         --enable_sflow_feature: Enable sFlow feature on DUT. Default is disabled
+
+        --enable_trail_run: Have a Trail Traffic run before running the actual sFlow tests. Default is disbled
 """
 
 import pytest

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -4,7 +4,7 @@
     Parameters:
         --enable_sflow_feature: Enable sFlow feature on DUT. Default is disabled
 
-        --enable_trail_run: Have a Trail Traffic run before running the actual sFlow tests. Default is disbled
+        --pre_learn_dst_mac: Learn the MAC before running the original test. Default is disbled
 """
 
 import pytest
@@ -92,7 +92,8 @@ def setup_ptf(ptfhost, collector_ports, var, tbinfo, request):
         ptfhost.shell('ifconfig eth%s %s/24' %(collector_ports[i],var['collector%s'%i]['ip_addr']))
     ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
 
-    if request.config.getoption("--enable_trail_run"):
+    if request.config.getoption("--pre_learn_dst_mac"):
+        logging.info("Early MAC Learning is enabled, before running the actual sFlow test")
         params = {'testbed_type': tbinfo['topo']['name'],
                   'router_mac': var['router_mac'],
                   'dst_port' : var['ptf_test_indices'][2],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The first sflow test case that runs i.e. "test_sflow_config" fails because of packet drops initially as the arp_responder takes time to respond. 

#### How did you do it?
Added an option "--enable_trail_run" to have a trail run before running the traffic and thereby the MAC for the destination is already learnt by the time the actual test starts.

For backward compatibility, i've set the option to 'False' by default.

#### How did you verify/test it?

```
py.test sflow/test_sflow.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern sonic-dut --module-path ../ansible/library/ --testbed sonic-dut-t0 --testbed_file ../ansible/testbed.csv      --allow_recover --assert plain --log-cli-level info --show-capture=no -ra --enable_sflow_feature --enable_trail_run --skip_sanity --showlocals -v
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
