### PR TITLE
[Mellanox] Thermal Mock Initialization failure fixed

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -38,8 +38,7 @@ THERMAL_NAMING_RULE = {
     "gearbox": {
         "name": "Gearbox {} Temp",
         "temperature": "gearbox{}_temp_input",
-        "high_threshold": "mlxsw-gearbox{}/temp_trip_hot",
-        "high_critical_threshold": "mlxsw-gearbox{}/temp_trip_crit"
+        "high_threshold": "mlxsw-gearbox{}/temp_trip_hot"
     },
     "asic_ambient": {
         "name": "ASIC",


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes: Test expects the gearbox critical temperature and as a result the test fails.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

```
20:29:09 mellanox_thermal_control_test_helper._do L0974 INFO   | Failed to mock thermal data for Gearbox 1 Temp - /var/run/hw-management/thermal/mlxsw-gearbox1/temp_trip_crit not exist 
20:29:13 mellanox_thermal_control_test_helper._do L0974 INFO   | Failed to mock thermal data for Gearbox 2 Temp - /var/run/hw-management/thermal/mlxsw-gearbox2/temp_trip_crit not exist 
<Truncated>
```
 
As a result:
```
20:34:48 mellanox_thermal_control_test_helper.che L0712 ERROR  | Found extra data in actual_data: [ 
[
   {
      "temperature":"0.023",
      "crit low th":"N/A",
      "high th":"0.028",
      "crit high th":"N/A",
      "warning":"False",
      "timestamp":"20210518 20:35:40",
      "low th":"N/A",
      "sensor":"Gearbox 1 Temp"
   },
   {
      "temperature":"0.039",
      "crit low th":"N/A",
      "high th":"0.044",
      "crit high th":"N/A",
      "warning":"False",
      "timestamp":"20210518 20:35:40",
      "low th":"N/A",
      "sensor":"Gearbox 2 Temp"
   },
   {
      "temperature":"0.008",
      "crit low th":"N/A",
      "high th":"0.013",
      "crit high th":"N/A",
      "warning":"False",
      "timestamp":"20210518 20:35:40",
      "low th":"N/A",
      "sensor":"Gearbox 3 Temp"
   }
]
<Truncated>

{ 
 "name": "platform_tests/test_platform_info.py::test_show_platform_temperature_mocked[msn3800-ignore_particular_error_log0]", 
"result": "failed" 
} 

<Truncated>

```

#### How did you do it?

#### How did you verify/test it?

Ran the Test Locally:

```
py.test platform_tests/test_platform_info.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern msn3800-sonic --module-path   ../ansible/library/ --testbed msn3800-sonic-ptf-any --testbed_file ../ansible/testbed.csv  --allow_recover  --log-cli-level debug --show-capture=no -ra --showlocals -k "test_show_platform_temperature_mocked or test_show_platform_fanstatus_mocked"


======================================================= 2 passed, 5 deselected in 999.96 seconds =======================================================
```




#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
