### PR TITLE
[PFCWD] [QOS] Test Case which triggers a PFC Storm when the occupancy crossed into shared headroom

### DIFF
--- a/tests/qos/Pfc_Storm_with_Shared_Headroom_test_plan.md
+++ b/tests/qos/Pfc_Storm_with_Shared_Headroom_test_plan.md
@@ -1,0 +1,29 @@
+# PFC Storm with Shared Headroom Test Plan
+
+## Motivation
+
+This test covers the scenrio when a PFC Watchdog is applied on a port which already has it's occupancy crossed into shared headroom. 
+
+The test checks if any PFC Frames are sent to the peer link from the DUT port. 
+
+**Note:** 
++ This test case is only intended for Mellanox Platforms
++ This test case requires an RPC image
++ Shared Headroom has to be enabled on the device.
+
+## Test Plan
++ Verify if the shared headroom is enabled
++ Make sure buffer occupancy crosses into the shared headroom region
+   - Achieve buffer congestion by closing the dut tx port using `sai_thrift_port_tx_disable` API: https://github.com/Azure/sonic-mgmt/blob/master/tests/saitests/switch.py#L624.
+   - Send pkts from the PTF docker which are destined to egress out of the dut tx port.
+   - Make sure to send atleast num_pkts_pfs_frame + private_headroom pkts pkts
+   - num_pkts_pfs_frame: num of pkts required to be sent in order to trigger a PFC frame from the DUT. More on this here: https://github.com/Azure/sonic-mgmt/blob/master/tests/qos/files/mellanox/qos_param_generator.py
+   - private_headroom_pkts is specific to mellanox which is in the order of a few pkts.
+   - Check the PFC Rx Counters to see verify if the occupancy has indeed crossed into 
+    
++ Trigger a PFC storm directed towards the DUT port
++ PFC Watchdog is triggered
++ After PFC WD is restored, drain the Ingress buffers to drop the occupancy under Xon
+  - Achieve this by re-opening dut tx port using `sai_thrift_port_tx_enable` API.
+  - This'll drain the  buffers and the occupancy falls below Xon.
++ Check the Tx PFC Counters on the DUT source port which was stormed after the packets are drained. They shouldn't be incremented as the occupancy has fallen below Xon

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -110,7 +110,6 @@ class QosParamMellanox(object):
         self.qos_parameters['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
         self.qos_parameters['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
         self.qos_parameters['pkts_num_hysteresis'] = hysteresis
-        self.qos_parameters['pkts_num_private_headrooom'] = self.asic_param_dic[self.asic_type]['private_headroom']
 
     def calculate_parameters(self):
         """
@@ -204,3 +203,4 @@ class QosParamMellanox(object):
             self.qos_params_mlnx['ecn_{}'.format(i+1)]['cell_size'] = self.cell_size
 
         self.qos_params_mlnx['shared-headroom-pool'] = self.sharedHeadroomPoolSize
+        self.qos_params_mlnx['pkts_num_private_headrooom'] = self.asic_param_dic[self.asic_type]['private_headroom']

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -6,17 +6,17 @@ class QosParamMellanox(object):
             'spc1': {
                 'cell_size': 96,
                 'headroom_overhead': 95,
-                'private_headroom': 15
+                'private_headroom': 30
             },
             'spc2': {
                 'cell_size': 144,
                 'headroom_overhead': 64,
-                'private_headroom': 15
+                'private_headroom': 30
             },
             'spc3': {
                 'cell_size': 144,
                 'headroom_overhead': 64,
-                'private_headroom': 15
+                'private_headroom': 30
             }
         }
 

--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -2,24 +2,27 @@ import math
 
 class QosParamMellanox(object):
     def __init__(self, qos_params, asic_type, speed_cable_len, dutConfig, ingressLosslessProfile, ingressLossyProfile, egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize):
-        asic_param_dic = {
+        self.asic_param_dic = {
             'spc1': {
                 'cell_size': 96,
-                'headroom_overhead': 95
+                'headroom_overhead': 95,
+                'private_headroom': 15
             },
             'spc2': {
                 'cell_size': 144,
-                'headroom_overhead': 64
+                'headroom_overhead': 64,
+                'private_headroom': 15
             },
             'spc3': {
                 'cell_size': 144,
-                'headroom_overhead': 64
+                'headroom_overhead': 64,
+                'private_headroom': 15
             }
         }
 
         self.asic_type = asic_type
-        self.cell_size = asic_param_dic[asic_type]['cell_size']
-        self.headroom_overhead = asic_param_dic[asic_type]['headroom_overhead']
+        self.cell_size = self.asic_param_dic[asic_type]['cell_size']
+        self.headroom_overhead = self.asic_param_dic[asic_type]['headroom_overhead']
         if speed_cable_len[0:6] == '400000':
             self.headroom_overhead += 59
             # for 400G ports we need an extra margin in case it is filled unbalancely between two buffer units
@@ -107,6 +110,7 @@ class QosParamMellanox(object):
         self.qos_parameters['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc
         self.qos_parameters['pkts_num_trig_egr_drp'] = pkts_num_trig_egr_drp
         self.qos_parameters['pkts_num_hysteresis'] = hysteresis
+        self.qos_parameters['pkts_num_private_headrooom'] = self.asic_param_dic[self.asic_type]['private_headroom']
 
     def calculate_parameters(self):
         """

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -603,7 +603,8 @@ class QosSaiBase(QosBase):
             "testPorts": testPorts,
             "qosConfigs": qosConfigs,
             "dutAsic" : dutAsic,
-            "dutTopo" : dutTopo
+            "dutTopo" : dutTopo,
+            "dutInstance" : duthost
         }
 
     @pytest.fixture(scope='class')

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -248,9 +248,8 @@ class TestQosSai(QosSaiBase):
         duthost.command("pfcwd stop")
 
         # set poll interval for pfcwd
-        duthost.command("pfcwd interval {}".format(pfcwd_timers['pfc_timers']['pfc_wd_poll_time']))
+        duthost.command("pfcwd interval {}".format(pfcwd_timers['pfc_wd_poll_time']))
 
-        """
         try:
             logger.info("---  Fill the ingress buffers ---")
             self.runPtfTest(
@@ -271,12 +270,12 @@ class TestQosSai(QosSaiBase):
             raise e
 
         finally:
+            logger.info("---  Enable all dst ports ---")
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.PtfEnableDstPorts", testParams=testParams
             )
             logger.info("--- Stopping Pfcwd ---")
             duthost.command("pfcwd stop")
-        """
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2"])
     def testQosSaiPfcXonLimit(

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -195,7 +195,7 @@ class TestQosSai(QosSaiBase):
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
             "pkts_num_trig_pfc": qosConfig[xonProfile]["pkts_num_trig_pfc"],
-            "pkts_num_private_headrooom": qosConfig[xonProfile]["pkts_num_private_headrooom"]
+            "pkts_num_private_headrooom": dutQosConfig["param"]["pkts_num_private_headrooom"]
         })
 
         # Params required for generating a PFC Storm

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -31,7 +31,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file          # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode
 from tests.common.helpers.pfc_storm import PFCStorm
-from tests.pfcwd.files.pfcwd_helper import set_pfc_timers
+from tests.pfcwd.files.pfcwd_helper import set_pfc_timers, start_wd_on_ports
 from qos_sai_base import QosSaiBase
 
 logger = logging.getLogger(__name__)
@@ -250,6 +250,12 @@ class TestQosSai(QosSaiBase):
         # set poll interval for pfcwd
         duthost.command("pfcwd interval {}".format(pfcwd_timers['pfc_wd_poll_time']))
 
+        logger.info("--- Start Pfcwd on port {}".format(pfcwd_test_port))
+        start_wd_on_ports(duthost,
+                          pfcwd_test_port,
+                          pfcwd_timers['pfc_wd_restore_time'],
+                          pfcwd_timers['pfc_wd_detect_time'])
+
         try:
             logger.info("---  Fill the ingress buffers ---")
             self.runPtfTest(
@@ -258,7 +264,7 @@ class TestQosSai(QosSaiBase):
 
             # Trigger PfcWd
             storm_hndle.start_storm()
-            time.sleep(2)
+            time.sleep(10)
             storm_hndle.stop_storm()
 
             logger.info("---  Re-Enable dst ifaces and verify if the PFC frames are not sent ---")

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -202,13 +202,10 @@ class TestQosSai(QosSaiBase):
             "buffer_max_size": ingressLosslessProfile["size"],
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
-            "dst_port_2_id": dutConfig["testPorts"]["dst_port_2_id"],
-            "dst_port_2_ip": dutConfig["testPorts"]["dst_port_2_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
             "pkts_num_trig_pfc": qosConfig[xonProfile]["pkts_num_trig_pfc"],
-            "pkts_margin_under_pfc": 8,
             "pkts_num_private_headrooom": 15
         })
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -142,8 +142,8 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2"])
     def testPfcStormWithSharedHeadroomOccupancy(
-        self, xonProfile, ptfhost, fanouthosts, conn_graph_facts,
-        fanout_graph_facts,  dutTestParams, dutConfig, dutQosConfig, ingressLosslessProfile
+        self, xonProfile, ptfhost, fanouthosts, conn_graph_facts,  fanout_graph_facts,
+        dutTestParams, dutConfig, dutQosConfig, sharedHeadroomPoolSize, ingressLosslessProfile
     ):
         """
             Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link. 
@@ -173,7 +173,8 @@ class TestQosSai(QosSaiBase):
         if "lag" in dutConfig["dutTopo"]:
             pytest.skip("Topology {} is not suppoted".format(dutConfig["dutTopo"]))
 
-        # TODO: Check if Shared Headroom is enabled
+        if not sharedHeadroomPoolSize or sharedHeadroomPoolSize == "0":
+            pytest.skip("Shared Headrrom has to be enabled for this test")
 
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         if xonProfile in dutQosConfig["param"][portSpeedCableLength].keys():

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -200,13 +200,28 @@ class TestQosSai(QosSaiBase):
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
             "pkts_num_trig_pfc": qosConfig[xonProfile]["pkts_num_trig_pfc"],
             "pkts_margin_under_pfc": 8,
-            "pkts_num_private_headrooom": 15,
-            "hwsku":dutTestParams['hwsku']
+            "pkts_num_private_headrooom": 15
         })
 
-        self.runPtfTest(
-            ptfhost, testCase="sai_qos_tests.PfcOccupySharedHeadroom", testParams=testParams
-        )
+        try:
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.PtfFillBuffer", testParams=testParams
+            )
+
+            # TODO: Generate a PFC Storm
+
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.PtfReleaseBuffer", testParams=testParams
+            )
+
+        except Exception as e:
+            raise e
+
+        finally:
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.PtfEnableDstPorts", testParams=testParams
+            )
+
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2"])
     def testQosSaiPfcXonLimit(

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -170,11 +170,8 @@ class TestQosSai(QosSaiBase):
         if dutTestParams["basicParams"]["sonic_asic_type"] != "mellanox":
             pytest.skip("This Test Case is only meant for Mellanox ASIC")
 
-        if "lag" in dutConfig["dutTopo"]:
-            pytest.skip("Topology {} is not suppoted".format(dutConfig["dutTopo"]))
-
         if not sharedHeadroomPoolSize or sharedHeadroomPoolSize == "0":
-            pytest.skip("Shared Headrrom has to be enabled for this test")
+            pytest.skip("Shared Headroom has to be enabled for this test")
 
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         if xonProfile in dutQosConfig["param"][portSpeedCableLength].keys():
@@ -198,7 +195,7 @@ class TestQosSai(QosSaiBase):
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
             "pkts_num_trig_pfc": qosConfig[xonProfile]["pkts_num_trig_pfc"],
-            "pkts_num_private_headrooom": 15
+            "pkts_num_private_headrooom": qosConfig[xonProfile]["pkts_num_private_headrooom"]
         })
 
         # Params required for generating a PFC Storm

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -136,6 +136,7 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams
         )
 
+    @pytest.mark.topology('ptf32')
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2"])
     def testPfcStormWithSharedHeadroomOccupancy(
         self, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -261,19 +261,18 @@ class TestQosSai(QosSaiBase):
 
             # Trigger PfcWd
             storm_hndle.start_storm()
+            logger.info("PfcWd Status: {}".format(duthost.command("pfcwd show stats")["stdout_lines"]))
             time.sleep(10)
             storm_hndle.stop_storm()
+            logger.info("PfcWd Status: {}".format(duthost.command("pfcwd show stats")["stdout_lines"]))
 
-            logger.info("---  Re-Enable dst ifaces and verify if the PFC frames are not sent ---")
+            logger.info("---  Enable dst iface and verify if the PFC frames are not sent from src port ---")
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.PtfReleaseBuffer", testParams=testParams
             )
-
         except Exception as e:
             raise e
-
         finally:
-            logger.info("---  Enable all dst ports ---")
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.PtfEnableDstPorts", testParams=testParams
             )

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -137,13 +137,13 @@ class TestQosSai(QosSaiBase):
         )
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2"])
-    def testContPfcFrmswithSharedHeadroom(
+    def testPfcStormWithSharedHeadroomOccupancy(
         self, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile
     ):
         """
             Verify if the PFC Frames are not sent from the DUT after a PFC Storm from peer link. 
-            Buffer occupancy must cross into shared headroom region when the PFC Storm is seen 
+            Ingress PG occupancy must cross into shared headroom region when the PFC Storm is seen 
             Only for MLNX Platforms
 
             Args:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -185,15 +185,6 @@ class TestQosSai(QosSaiBase):
             else:
                 qosConfig = dutQosConfig["param"]
 
-
-        dst_port_count = set([
-            dutConfig["testPorts"]["dst_port_id"],
-            dutConfig["testPorts"]["dst_port_2_id"]
-        ])
-
-        if len(dst_port_count) != 2:
-            pytest.skip("PFC Xon Limit test: Need at least 2 destination ports")
-
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -918,7 +918,7 @@ class PfcOccupySharedHeadroom(sai_base_test.ThriftInterfaceDataPlane):
 
         # get a snapshot of ingress pg occupancy for the source port
         pg_cntrs_base = sai_thrift_read_pg_shared_watermark(
-            self.client, port_list[src_port_id]
+            self.client, asic_type, port_list[src_port_id]
         )
 
         #  Margin used to cross the shared headrooom boundary
@@ -993,7 +993,7 @@ class PfcOccupySharedHeadroom(sai_base_test.ThriftInterfaceDataPlane):
             xmit_2_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
             # get a snapshot of ingress pg shared occupancy for the source port after sending pkts
             pg_cntrs = sai_thrift_read_pg_shared_watermark(
-                self.client, port_list[src_port_id]
+                self.client, asic_type, port_list[src_port_id]
             )
 
             logging.debug("Recv Counters: {}, Base: {}".format(recv_counters, recv_counters_base))

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -917,7 +917,7 @@ class PfcOccupySharedHeadroom(sai_base_test.ThriftInterfaceDataPlane):
         )
 
         # get a snapshot of ingress pg occupancy for the source port
-        queue_res, pg_shared_res_base, pg_headroom_res = sai_thrift_read_port_watermarks(
+        pg_cntrs_base = sai_thrift_read_pg_shared_watermark(
             self.client, port_list[src_port_id]
         )
 
@@ -991,20 +991,20 @@ class PfcOccupySharedHeadroom(sai_base_test.ThriftInterfaceDataPlane):
             recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
             xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
             xmit_2_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[dst_port_2_id])
-            # get a snapshot of ingress pg occupancy for the source port after sending pkts
-            queue_res, pg_shared_res, pg_headroom_res = sai_thrift_read_port_watermarks(
+            # get a snapshot of ingress pg shared occupancy for the source port after sending pkts
+            pg_cntrs = sai_thrift_read_pg_shared_watermark(
                 self.client, port_list[src_port_id]
             )
 
             logging.debug("Recv Counters: {}, Base: {}".format(recv_counters, recv_counters_base))
             logging.debug("Xmit Counters: {}, Base: {}".format(xmit_counters, xmit_counters_base))
             logging.debug("Xmit_2 Counters: {}, Base: {}".format(xmit_2_counters, xmit_2_counters_base))
-            logging.debug("Recv Ingress PG Counters: {}, Base: {}".format(pg_shared_res, pg_shared_res_base))
+            logging.debug("Recv Ingress PG Occupancy: {}, Base: {}".format(pg_cntrs, pg_cntrs_base))
 
             # recv port pfc
             assert(recv_counters[pg] > recv_counters_base[pg])
             # Verify if the occupancy has crossed into shared headroom
-            assert(pg_shared_res[pg_id] > pg_shared_res_base[pg_id])
+            assert(pg_cntrs[pg_id] > pg_cntrs_base[pg_id])
             # recv port no ingress drop
             for cntr in ingress_counters:
                 assert(recv_counters[cntr] == recv_counters_base[cntr])

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1015,8 +1015,8 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
             self.client, port_list[self.dst_port_2_id]
         )
 
-        logging.info("Enable xmit port: {}".format(self.dst_port_2_id))
-        sai_thrift_port_tx_enable(self.client, self.asic_type, [self.dst_port_2_id])
+        logging.info("Enable xmit ports: {}".format([self.dst_port_2_id, self.dst_port_id]))
+        sai_thrift_port_tx_enable(self.client, self.asic_type, [self.dst_port_id, self.dst_port_2_id])
 
         # allow enough time for the dut to sync up the counter values in counters_db
         time.sleep(8)

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -977,20 +977,13 @@ class PtfFillBuffer(PfcStormTestWithSharedHeadroom):
         recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[self.src_port_id])
         xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[self.dst_port_id])
         xmit_2_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[self.dst_port_2_id])
-        # get a snapshot of ingress pg shared occupancy for the source port after sending pkts
-        pg_cntrs = sai_thrift_read_pg_shared_watermark(
-            self.client, self.asic_type, port_list[self.src_port_id]
-        )
 
         logging.debug("Recv Counters: {}, Base: {}".format(recv_counters, recv_counters_base))
         logging.debug("Xmit Counters: {}, Base: {}".format(xmit_counters, xmit_counters_base))
         logging.debug("Xmit_2 Counters: {}, Base: {}".format(xmit_2_counters, xmit_2_counters_base))
-        logging.debug("Recv Shrd Hdrm Occupancy: {}, Base: {}".format(pg_cntrs, pg_cntrs_base))
 
         # recv port pfc
         assert(recv_counters[self.pg] > recv_counters_base[self.pg])
-        # Verify if the occupancy has crossed into shared headroom
-        assert(pg_cntrs[self.pg_id] > pg_cntrs_base[self.pg_id])
         # recv port no ingress drop
         for cntr in self.ingress_counters:
             assert(recv_counters[cntr] == recv_counters_base[cntr])

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1061,6 +1061,8 @@ class PtfReleaseBuffer(PfcStormTestWithSharedHeadroom):
 class PtfEnableDstPorts(PfcStormTestWithSharedHeadroom):
 
     def runTest(self):
+        time.sleep(1)
+        switch_init(self.client)
         self.parse_test_params()
         sai_thrift_port_tx_enable(self.client, self.asic_type, [self.dst_port_id, self.dst_port_2_id])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Tested on the device which had this problem.

```
"start": "2022-06-17 07:11:28.679981", 
    "stderr": "sai_qos_tests.PtfReleaseBuffer ... FAIL\n\n======================================================================\nFAIL: sai_qos_tests.PtfReleaseBuffer\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"saitests/sai_qos_tests.py\", line 1003, in runTest\n    assert(recv_counters[self.pg] == recv_counters_base[self.pg])\nAssertionError\n\n----------------------------------------------------------------------\nRan 1 test in 50.595s\n\nFAILED (failures=1)", 
    "stderr_lines": [
        "sai_qos_tests.PtfReleaseBuffer ... FAIL", 
        "", 
        "======================================================================", 
        "FAIL: sai_qos_tests.PtfReleaseBuffer", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"saitests/sai_qos_tests.py\", line 1003, in runTest", 
        "    assert(recv_counters[self.pg] == recv_counters_base[self.pg])", 
        "AssertionError", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 50.595s", 
        "", 
        "FAILED (failures=1)"
    ], 
    "stdout": "", 
    "stdout_lines": []
```

Verified on 202012 branch as well

After the storm was restored and packets were drained, the switch still sends PFC frames and the test detects it.

```
admin@mtbc-sonic-01-2410:~$ pfcwd show stats
      QUEUE    STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
-----------  --------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet4:3       N/A                        1/1           0/0           0/0                0/0                0/0
admin@mtbc-sonic-01-2410:~$ show pfc counters | grep -E '\<Ethernet4\>'
  Ethernet4       0       0       0  2,565,200       0       0       0       0
  Ethernet4       0       0       0  257,943       2       0       0       0
admin@mtbc-sonic-01-2410:~$ show pfc counters | grep -E '\<Ethernet4\>'
  Ethernet4       0       0       0  2,565,200       0       0       0       0
  Ethernet4       0       0       0  263,911       2       0       0       0
admin@mtbc-sonic-01-2410:~$ show pfc counters | grep -E '\<Ethernet4\>'
  Ethernet4       0       0       0  2,565,200       0       0       0       0
  Ethernet4       0       0       0  375,742       2       0       0       0
```

**Counters Recorded by PTF Docker**
The time diff b/w counters is 30 sec. Both of these are collected after the watchdog is restored and the packets are drained (i.e. dst port is re-enabled)
There shouldn't be any any increment in  SAI_PORT_STAT_PFC_3_TX_PKTS values but there is one indicating a faulty behavior
```
07:12:20.365  root      : DEBUG   : Recv Counters: [0, 0, 0, 0, 0, 83369, 2, 0, 0, 0, 5347560, 1, 0, 0], Base: [0, 0, 0, 0, 0, 38597, 2, 0, 0, 0, 2482152, 1, 0, 0]
```

#### Any platform specific information?

Yes, only for Mellanox platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
